### PR TITLE
CloudStorageManager and VolumeManager integration.

### DIFF
--- a/dom/system/gonk/VolumeManager.cpp
+++ b/dom/system/gonk/VolumeManager.cpp
@@ -156,6 +156,21 @@ VolumeManager::FindAddVolumeByName(const nsCSubstring& aName)
 }
 
 //static
+void
+VolumeManager::RemoveVolumeByName(const nsCSubstring& aName)
+{
+  VolumeArray::size_type  numVolumes = NumVolumes();
+  VolumeArray::index_type volIndex;
+  for (volIndex = 0; volIndex < numVolumes; volIndex++) {
+    RefPtr<Volume> vol = GetVolume(volIndex);
+    if (vol->Name().Equals(aName)) {
+      break;
+    }
+  }
+  sVolumeManager->mVolumeArray.RemoveElementAt(volIndex);
+}
+
+//static
 void VolumeManager::InitConfig()
 {
   MOZ_ASSERT(MessageLoop::current() == XRE_GetIOMessageLoop());

--- a/dom/system/gonk/VolumeManager.h
+++ b/dom/system/gonk/VolumeManager.h
@@ -128,6 +128,7 @@ public:
   static TemporaryRef<Volume> GetVolume(VolumeArray::index_type aIndex);
   static TemporaryRef<Volume> FindVolumeByName(const nsCSubstring& aName);
   static TemporaryRef<Volume> FindAddVolumeByName(const nsCSubstring& aName);
+  static void RemoveVolumeByName(const nsCSubstring& aName);
   static void InitConfig();
 
   static void       PostCommand(VolumeCommand* aCommand);

--- a/dom/system/gonk/cloudstorage/CloudStorage.cpp
+++ b/dom/system/gonk/cloudstorage/CloudStorage.cpp
@@ -30,10 +30,9 @@ public:
   { 
     CloudStorageRequestHandler* handler = new CloudStorageRequestHandler(mCloudStorage->MountPoint());
     if (handler) {
-      /*
       RefPtr<Volume> vol = VolumeManager::FindAddVolumeByName(mCloudStorage->Name());
-      vol->SetCloudVolume(mCloudStorage->MountPoint());
-      */
+      vol->SetFakeVolume(mCloudStorage->MountPoint());
+      VolumeManager::Dump("CloudStorage");
       while (mCloudStorage->State() == CloudStorage::STATE_RUNNING) {
         //handler->HandleOneRequest();
 	sleep(1);
@@ -41,7 +40,9 @@ public:
     } else {
       LOG("Construct cloud storage handler fail");
     }
+    VolumeManager::RemoveVolumeByName(mCloudStorage->Name());
     delete handler;
+    VolumeManager::Dump("CloudStorage");
     LOG("going to finish RequestHandler.");
     return NS_OK;
   }


### PR DESCRIPTION
After this patch, CloudStorageService API enable/disable can
mount/unmount FUSE with the specified name under /data/cloud/<name>.
And create/remote a fake volume in VolumeManager, and Web app can
access the volume through DeviceStorageAPI.
